### PR TITLE
Update section heading in readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,11 +4,13 @@
 
 MDN Web Docs is an open-source, collaborative project that documents web platform technologies, including CSS, HTML, JavaScript, and Web APIs. We also provide extensive 👨🏿‍🎓 learning resources for beginning developers and students.
 
-## 🙌 MDN's mission is to provide a blueprint for a better internet and empower a new generation of developers and content creators to build it.
+### 🙌 MDN's mission
+
+MDN's mission is to provide a blueprint for a better internet and empower a new generation of developers and content creators to build it.
 
 The power of MDN Web Docs lies in its vast community of active readers and contributors. Since 2005, approximately 45,000 contributors have created the documentation we know and love. Together, contributors have created over 45,000 documents that make up an up-to-date, comprehensive, and free resource for web developers worldwide. In addition to English-language articles, over 35 volunteers lead translation and localization efforts for 🇨🇳 Chinese, 🇫🇷 French, 🇯🇵 Japanese, 🇰🇷 Korean, 🇵🇹 Portuguese, 🇷🇺 Russian, and 🇪🇸 Spanish.
 
-### 🧑🏼‍🤝‍🧑  Be part of MDN Web Docs
+### 🤝 Be part of MDN Web Docs
 You can be part of MDN Web Docs, whether it be through ✍🏽 content contributions, ⚙️ engineering, or ↔️ translation work. The MDN Web Docs project welcomes contributions from everyone who shares our goals and wants to contribute constructively and respectfully within our community. 🧘‍♂️
 
 ### ✉️ Get in touch


### PR DESCRIPTION
Sorry, @schalkneethling. My bad - I completely missed that the 'MDN's Mission' sentence is a header and as such it is is a very long title. And now that I see the page live, I have a few more suggestions.

1. For the 'MDN's Mission' title, there are a couple of options:
- Reduce the title to "MDN's mission" and move the remaining bit to the paragraph (which is what I have done in this PR)
- We remove that header and title completely and just retain the three paragraphs

2. If we retain the mission title, I think we definitely need to make that header to be at the same level as "Be part of MDN Web Docs" and "Get in touch" (done in this PR) because the other two sections are not sub-sections of the mission section.

3. Also, I've reduced the emoji in "Be part of MDN Web Docs" to a single one so that all the titles visually align vertically.